### PR TITLE
Fix incorrect isValidToken comparison between seconds and milliseconds

### DIFF
--- a/src/access-provider.ts
+++ b/src/access-provider.ts
@@ -69,10 +69,10 @@ export class AccessProvider {
       return false;
     }
 
-    const shouldExpireBy = parseInt(this.apiAuthorization.issued_at) + parseInt(this.apiAuthorization.expires_in);
-    const now = new Date().getTime();
+    const shouldExpireBySeconds = parseInt(this.apiAuthorization.issued_at) + parseInt(this.apiAuthorization.expires_in);
+    const nowSeconds = new Date().getTime() / 1000;
 
-    if (now > shouldExpireBy - 3600) {
+    if (nowSeconds > shouldExpireBySeconds - 3600) {
       delete this.apiAuthorization;
       delete this.apiAccessTokenPromise;
       return false;


### PR DESCRIPTION
_Use this template to give context and details about what your changes bring to the project. You should complete as many sections as possible, deleting those that are not relevant._

### Ticket 🎟
[XXX-xxx]

</br>

### What ⁉️
_What are these changes? Please include screenshots for UI changes_
Fix error in isValidToken logic, both issued_at and expires_in are in seconds but compares to Date.getTime() which returns milliseconds
<img width="510" height="184" alt="image" src="https://github.com/user-attachments/assets/74730e92-bbe8-4567-aa12-d0df160b289c" />

### Why ⁉️
_Why are these changes necessary?_
Current isValidToken function causes a new token to be requested for each call.
Can result in 500 responses from API if too many requests per second

### How ⁉️
_How have you approached making these changes?_
Divide Date.getTime() by 1000 to get seconds, and rename variables to understand what time interval the expiry is defined in

### How to review and test 📱
_Please provide details on how the reviewer should review your changes and the best way for them to test them._
Run two subsequent requests with API, should reuse the same token.

</br>

### Checklist ✅
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests are passing locally
